### PR TITLE
added options object, with replace and separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,16 @@
  *        // > foo-bar
  *
  * @param {String} str
- * @param {String} repl defaulted to `-`
+ * @param {Object} options
+ * @config {String|RegExp} [replace] characters to replace, defaulted to `/[^a-z0-9]/g`
+ * @config {String} [separator] separator to insert, defaulted to `-`
  * @return {String}
  */
 
-module.exports = function (str, repl) {
+module.exports = function (str, options) {
+  options || (options = {});
   return str.toLowerCase()
-    .replace(/[^a-z0-9]/g, ' ')
+    .replace(options.replace || /[^a-z0-9]/g, ' ')
     .replace(/^ +| +$/g, '')
-    .replace(/ +/g, repl || '-')
+    .replace(/ +/g, options.separator || '-')
 };

--- a/test/slug.js
+++ b/test/slug.js
@@ -24,8 +24,12 @@ describe('slug()', function () {
     assert(gen('@!#!@#!@#foo bar1232') == 'foo-bar1232');
   })
 
-  it('should respect `replacement` parameter', function () {
-    assert(gen('foo bar', '_') == 'foo_bar');
+  it('should respect `separator` option', function () {
+    assert(gen('foo bar', { separator: '_' }) == 'foo_bar');
+  })
+
+  it('should respect `replace` option', function () {
+    assert(gen('foo bar', { replace : /o/g }) == 'f-bar');
   })
 
   it('should trim', function () {


### PR DESCRIPTION
added ability to choose which characters are placed. for example, i'd like to let my slugs maintain domain/file names like `http://example.docs/repos/github.com`

figured this should convert the `repl` argument into an `options` object.

the replacement seemed to make sense as `options.replace`, especially since it's passed directly to a `.replace` method. and the original `repl` made more sense as a `options.separator`.

leme know what you think
